### PR TITLE
ユーザーリスト関連ソースのリファクタリング

### DIFF
--- a/repositories/mongo_repository.py
+++ b/repositories/mongo_repository.py
@@ -6,6 +6,7 @@ import pymongo
 from pymongo import MongoClient
 
 from common.get_logger import get_logger
+from templates.select_option_to_entry_template import ENTRY_OPTION_ID_ATTEND, ENTRY_OPTION_ID_HALFWAY
 
 load_dotenv()
 logger = get_logger(__name__, os.environ.get("LOGGER_LEVEL"))
@@ -99,8 +100,8 @@ def generate_member_info_dict(events: list) -> dict[str, MemberInfo]:
         for entry in entries:
             key: str = entry["user"]["userId"]
             display_name: str = entry["user"]["displayName"]
-            entry_status: int = int(entry["selectedOptionId"])
             picture_url: str = entry["user"]["pictureUrl"]
+            entry_status: str = entry["selectedOptionId"]
             event_datetime: datetime = event["startTime"]
             
             if key not in results:
@@ -108,8 +109,9 @@ def generate_member_info_dict(events: list) -> dict[str, MemberInfo]:
                 
             if (results[key].firstAttendanceDateTime > event_datetime):
                 results[key].setFirstAttendanceDateTime(event_datetime)
-            
-            if (entry_status <= 2): #See the definition of entry stats in select_option_to_entry_template.py.
+
+            # See the definition of entry stats in select_option_to_entry_template.py.
+            if entry_status is ENTRY_OPTION_ID_ATTEND or entry_status is ENTRY_OPTION_ID_HALFWAY:
                 results[key].setTotalAttendance(results[key].totalAttendance + 1)
     
     return results

--- a/repositories/mongo_repository.py
+++ b/repositories/mongo_repository.py
@@ -75,20 +75,20 @@ def find_all_members_in_the_event(event_id: ObjectId) -> dict:
 class MemberInfo:
     displayName: str
     pictureUrl: str
-    firstAttendanceDateTime: datetime
+    firstEntryDateTime: datetime
     totalAttendance: int
     
-    def __init__(self, displayName: str, pictureUrl: str, firstAttendanceDateTime:datetime = datetime(2099,1,1), totalAttendance: int = 0):
+    def __init__(self, displayName: str, pictureUrl: str, firstEntryDateTime:datetime = datetime(2099, 1, 1), totalAttendance: int = 0):
         self.displayName = displayName
         self.pictureUrl = pictureUrl
-        self.firstAttendanceDateTime = firstAttendanceDateTime
+        self.firstEntryDateTime = firstEntryDateTime
         self.totalAttendance = totalAttendance
         
     def setTotalAttendance(self, totalAttendance:int) ->None:
         self.totalAttendance = totalAttendance
         
-    def setFirstAttendanceDateTime(self, firstAttendanceDateTime: datetime) ->None:
-        self.firstAttendanceDateTime = firstAttendanceDateTime
+    def setFirstEntryDateTime(self, firstEntryDateTime: datetime) ->None:
+        self.firstEntryDateTime = firstEntryDateTime
 
 # key: string class. User's objectID from MongoDB
 # Value: MemberInfo class.
@@ -107,8 +107,8 @@ def generate_member_info_dict(events: list) -> dict[str, MemberInfo]:
             if key not in results:
                 results[key] = MemberInfo(display_name, picture_url)
                 
-            if (results[key].firstAttendanceDateTime > event_datetime):
-                results[key].setFirstAttendanceDateTime(event_datetime)
+            if results[key].firstEntryDateTime > event_datetime:
+                results[key].setFirstEntryDateTime(event_datetime)
 
             # See the definition of entry stats in select_option_to_entry_template.py.
             if entry_status is ENTRY_OPTION_ID_ATTEND or entry_status is ENTRY_OPTION_ID_HALFWAY:

--- a/services/postback_service.py
+++ b/services/postback_service.py
@@ -31,7 +31,7 @@ def show_members_message() -> list[FlexSendMessage]:
     #TODO Check if users are coming to the next event.　(Y/N)
     #TODO sort the user list by attendance to the next event. The absentees come first.
     
-    sorted_members_info = dict(sorted(members_info.items(), key=lambda item: (item[1].firstAttendanceDateTime, item[1].displayName)))
+    sorted_members_info = dict(sorted(members_info.items(), key=lambda item: (item[1].firstEntryDateTime, item[1].displayName)))
 
     #Generate flex send messages
     flex_messages = []   


### PR DESCRIPTION
* firstAttendanceDateTime をfirstEntryDateTimeにリネーム
    * 実際の動作に合わせるため。ここで取得される日付は「不参加」で参加登録したときの日付も含む。
* entryStatusをint型にキャストせずにそのままselect_option_to_entry_template.py内の文字列型シンボルと比較する
    * 該当箇所でしか使っていない変数だと想定していますが、問題あれば言ってください
   